### PR TITLE
Added functionality for finding peaks of multiple files within a given directory.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy==1.18.0
 pandas==1.0.1
 xlrd==1.1.0
 openpyxl==3.0.3
+xlsxwriter==1.2.8

--- a/scripts/peaks_finder_driver
+++ b/scripts/peaks_finder_driver
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import os
 import pandas as pd

--- a/scripts/peaks_finder_driver.py
+++ b/scripts/peaks_finder_driver.py
@@ -1,7 +1,12 @@
 import sys
+import os
 import pandas as pd
 from peaks_utils import clean_table, find_peaks, save_peaks_as_excel
-from utils import parse_inputs, create_default_output_path
+from utils import parse_inputs, create_default_output_path, list_directory_files
+
+SHEET_NAME = 'Peaks Results'
+INPUT_COLUMNS = ['Centroid Mass', 'Relative Intensity']  # Columns of Interest in input files
+OUTPUT_COLUMNS = ['Centroid Mass 1', 'Relative Intensity 1', 'Centroid Mass 2', 'Relative Intensity Mass 2']
 
 
 def main():
@@ -18,19 +23,52 @@ def main():
     if not output_fp:
         output_fp = create_default_output_path()
 
-    # Read File
-    table_df = pd.read_excel(input_fp)
+    # Mapping of file_name to file_path
+    files_mapping = {}
 
-    # Clean and parse data
-    clean_table_df = clean_table(table_df)
-    columns = ['Centroid Mass', 'Relative Intensity']
-    mass_intensity_df = clean_table_df[columns]
+    # If input path is a file
+    if os.path.isfile(input_fp):
+        files_mapping = {os.path.split(input_fp)[1]: input_fp}
 
-    # Discover peaks
-    result = find_peaks(mass_intensity_df, intensity_tolerance, mass_shift, mass_tolerance)
+    # If input path is a directory
+    elif os.path.isdir(input_fp):
+        files_mapping = list_directory_files(input_fp)
 
-    # Write to output
-    save_peaks_as_excel(result, output_fp)
+    # Initialize Excel Writer
+    output_writer = pd.ExcelWriter(output_fp, engine='xlsxwriter')
+    workbook = output_writer.book
+    worksheet = workbook.add_worksheet(SHEET_NAME)
+    output_writer.sheets[SHEET_NAME] = worksheet
+
+    # Initialize Pointer to the current row that is up next to write in
+    current_row = 0
+
+    # Iterate through all files and write to single excel file
+    for file_name, file_path in files_mapping.items():
+
+        # Read File
+        table_df = pd.read_excel(file_path)
+
+        # Clean and parse data
+        clean_table_df = clean_table(table_df)
+        mass_intensity_df = clean_table_df[INPUT_COLUMNS]
+
+        # Discover peaks
+        result = find_peaks(mass_intensity_df, intensity_tolerance, mass_shift, mass_tolerance)
+
+        # Write File Name as the header for the current data section.
+        worksheet.write_string(current_row, 0, file_name)
+        current_row += 1  # Increment row pointer
+
+        # Write Peaks Data
+        df = pd.DataFrame(result, columns=OUTPUT_COLUMNS)
+        df.to_excel(output_writer, sheet_name=SHEET_NAME, startrow=current_row, startcol=0)
+
+        # Increment current_row pointer
+        current_row += df.shape[0] + 2  # Number of rows of data written plus 2 rows for buffer
+
+    # Close Output writer
+    output_writer.close()
 
 
 if __name__ == "__main__":

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -39,3 +39,16 @@ def create_default_output_path():
     # Return the default output file path string
     current_time = time.strftime("%Y_%m_%d-%H%M%S")
     return "{}/peaks_{}.xlsx".format(output_dir, current_time)
+
+
+def list_directory_files(dir_path):
+    """
+    Gets all filepaths from a given string representing the target directory path.
+    :param dir_path: (str) target directory path
+    :return: Dictionary mapping file_name to its full file_path
+    """
+
+    # Get all file names
+    file_names = os.listdir(dir_path)
+    # Return dictionary mapping {file_name: full file_path}
+    return {file_name: os.path.join(dir_path, file_name) for file_name in file_names}


### PR DESCRIPTION
# Summary
Prior, the peaks finder utility only accepted a single file as input.

The changes added in this PR will allow the script to accept either a single file or a directory full of `xlsx` files as input to be processed.

# Usage
## Script with Input File example
`./peaks_finder_driver.py -i test_files/TGase\ Bromonitro\ Mass\ List\ \(1\).xlsx -m 2`

## Single File Output: 
![image](https://user-images.githubusercontent.com/15353453/75598785-738fe780-5a6c-11ea-8e11-8e3ddba0f8d1.png)


## Script with Input Directory Example
`./peaks_finder_driver.py -i test_files/ -m 2`

## Directory Example Output
![image](https://user-images.githubusercontent.com/15353453/75598806-b05bde80-5a6c-11ea-8650-76cb328bab56.png)

# Notes
Due to a depreciation of one of the dependencies of pandas in read_excel, we cannot read `.xls` files. As of now this script ONLY takes in `.xlsx` files. Link to the relevant issue is documented here: https://github.com/pandas-dev/pandas/issues/11503

# EDIT (MARCH 4, 2020)

Made the script into an executable. You now run the script as follows:

```./peaks_finder_driver -i <input_path> -m <mass_shift>```

Alternatively, you can also use the previous method as well:
```python3 peaks_finder_driver -i <input_path> -m <mass_shift>```
